### PR TITLE
Runde 1

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -47,7 +47,6 @@ module.exports = function() {
       process.on(signal, function () {
         log.info("Got %s, shutting down alexa-fhem...", signal);
 
-<<<<<<< HEAD
         //server.shutdown(() => { process.exit(128 + signals[signal]) } );
         server.shutdown();
 
@@ -55,12 +54,6 @@ module.exports = function() {
           process.exit(128 + signals[signal])
         }, 2000);
       });
-=======
-      //server.shutdown(() => { process.exit(128 + signals[signal]) } );
-      server.shutdown();
-
-      setTimeout(() => {process.exit(128 + signals[signal]) }, 2000 );
->>>>>>> 8f182e366362656eec43d6619b5993aeaeba0e16
     });
 
     server.run();

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -9,6 +9,13 @@ var FHEM = require('./fhem').FHEM;
 
 module.exports = function() {
 
+  // What has to be done before we can start the servers? Default: nothing;
+  let startupPromise = new Promise(function (resolve) {
+    resolve();
+  });
+
+  var server;
+
   program
     .version(version)
     .option('-U, --user-storage-path [path]', 'look for alexa user files at [path] instead of the default location (~/.alexa)', function(p) { User.setStoragePath(p); })
@@ -18,31 +25,46 @@ module.exports = function() {
     //.option('-P, --proxy', 'run as proxy', function() { Server.asProxy(true) })
     .option('-a, --auth [auth]', 'user:password for fhem connection', function(a) { FHEM.auth(a) })
     .option('-s, --ssl', 'use https for fhem connection', function() { FHEM.useSSL(true) })
+    .option('-A, --autoconfig', 'automatically try to create config, find FHEM and prepare for public skill',
+       function() { startupPromise = User.autoConfig(true); })
     .parse(process.argv);
 
-  var server = new Server();
+  startupPromise.then(() => {
+    server = new Server();
 
-  process.on('disconnect', function() {
-    console.log('parent exited')
-    server.shutdown();
-  });
+    process.on('disconnect', function () {
+      console.log('parent exited')
+      server.shutdown();
+    });
 
-  process.stdin.on( 'end', function() {
-    console.log('STDIN EOF')
-    server.shutdown();
-  });
+    process.stdin.on('end', function () {
+      console.log('STDIN EOF')
+      server.shutdown();
+    });
 
-  var signals = { 'SIGINT': 2, 'SIGTERM': 15 };
-  Object.keys(signals).forEach(function (signal) {
-    process.on(signal, function () {
-      log.info("Got %s, shutting down alexa-fhem...", signal);
+    var signals = {'SIGINT': 2, 'SIGTERM': 15};
+    Object.keys(signals).forEach(function (signal) {
+      process.on(signal, function () {
+        log.info("Got %s, shutting down alexa-fhem...", signal);
 
+<<<<<<< HEAD
+        //server.shutdown(() => { process.exit(128 + signals[signal]) } );
+        server.shutdown();
+
+        setTimeout(() => {
+          process.exit(128 + signals[signal])
+        }, 2000);
+      });
+=======
       //server.shutdown(() => { process.exit(128 + signals[signal]) } );
       server.shutdown();
 
       setTimeout(() => {process.exit(128 + signals[signal]) }, 2000 );
+>>>>>>> 8f182e366362656eec43d6619b5993aeaeba0e16
     });
-  });
 
-  server.run();
+    server.run();
+  }).catch((reason) => {
+    console.error("Startup rejected. Reason: " + reason);
+  })
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -294,11 +294,7 @@ Server.prototype.open_ssh = function() {
       const delay = 15000 + Math.random()*120000;
       const date = new Date(new Date().getTime()+delay);
       let d = [ date.getHours(), date.getMinutes(), date.getSeconds()];
-<<<<<<< HEAD
       d = d.map(d => { return d<10 ? "0" + d.toString() : d.toString()});
-=======
-      d.map(d => { return d<10 ? "0" + d.toString() : d.toString()});
->>>>>>> 8f182e366362656eec43d6619b5993aeaeba0e16
       log.error('SSH: exited with ' + code + ' - will restart in ' + delay/1000 + ' seconds');
       ssh_client = undefined;
       this.set_ssh_state( 'stopped', 'Terminated with ' + code + ', ssh will restart at ' + d.join(':') );
@@ -365,20 +361,12 @@ Server.prototype.addDevice = function(device, fhem) {
 
 Server.prototype.setreading = function(reading, value) {
   log.info ("Reading " + reading + " set to " + value);
-<<<<<<< HEAD
   if ( this.connections )
     for( let fhem of this.connections ) {
       if (!fhem.alexa_device) continue;
       log.info("Found alexa");
       fhem.execute('setreading ' + fhem.alexa_device.Name + ' ' + reading + ' ' + value);
     }
-=======
-  for( let fhem of this.connections ) {
-    if( !fhem.alexa_device ) continue;
-    log.info ("Found alexa");
-    fhem.execute( 'setreading '+ fhem.alexa_device.Name +' '+ reading +' '+ value );
-  }
->>>>>>> 8f182e366362656eec43d6619b5993aeaeba0e16
 }
 
 Server.prototype.run = function() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -294,7 +294,11 @@ Server.prototype.open_ssh = function() {
       const delay = 15000 + Math.random()*120000;
       const date = new Date(new Date().getTime()+delay);
       let d = [ date.getHours(), date.getMinutes(), date.getSeconds()];
+<<<<<<< HEAD
+      d = d.map(d => { return d<10 ? "0" + d.toString() : d.toString()});
+=======
       d.map(d => { return d<10 ? "0" + d.toString() : d.toString()});
+>>>>>>> 8f182e366362656eec43d6619b5993aeaeba0e16
       log.error('SSH: exited with ' + code + ' - will restart in ' + delay/1000 + ' seconds');
       ssh_client = undefined;
       this.set_ssh_state( 'stopped', 'Terminated with ' + code + ', ssh will restart at ' + d.join(':') );
@@ -361,11 +365,20 @@ Server.prototype.addDevice = function(device, fhem) {
 
 Server.prototype.setreading = function(reading, value) {
   log.info ("Reading " + reading + " set to " + value);
+<<<<<<< HEAD
+  if ( this.connections )
+    for( let fhem of this.connections ) {
+      if (!fhem.alexa_device) continue;
+      log.info("Found alexa");
+      fhem.execute('setreading ' + fhem.alexa_device.Name + ' ' + reading + ' ' + value);
+    }
+=======
   for( let fhem of this.connections ) {
     if( !fhem.alexa_device ) continue;
     log.info ("Found alexa");
     fhem.execute( 'setreading '+ fhem.alexa_device.Name +' '+ reading +' '+ value );
   }
+>>>>>>> 8f182e366362656eec43d6619b5993aeaeba0e16
 }
 
 Server.prototype.run = function() {

--- a/lib/user.js
+++ b/lib/user.js
@@ -101,11 +101,7 @@ async function runAutoconfig(interactive, config) {
 
   if (! config) {
     const configPath = User.configPath();
-<<<<<<< HEAD
     config = {};
-=======
-    let config = {};
->>>>>>> 8f182e366362656eec43d6619b5993aeaeba0e16
     if (!fs.existsSync(configPath)) {
       if (fs.existsSync("./config-sample.json")) {
         console.log("config.json not existing, creating from ../config-sample.json");
@@ -136,10 +132,6 @@ async function runAutoconfig(interactive, config) {
     // Default settings for alexa-fhem
     if (!config.alexa.hasOwnProperty('port')) {
       config.alexa.port = 3000;
-<<<<<<< HEAD
-=======
-      dirty = true
->>>>>>> 8f182e366362656eec43d6619b5993aeaeba0e16
     }
     if (!config.alexa.hasOwnProperty('name')) {
       config.alexa.name = 'Alexa';
@@ -149,10 +141,6 @@ async function runAutoconfig(interactive, config) {
       config.alexa['bind-ip'] = '127.0.0.1';
       dirty = true
     }
-<<<<<<< HEAD
-
-=======
->>>>>>> 8f182e366362656eec43d6619b5993aeaeba0e16
     if (!config.alexa.hasOwnProperty('ssl')) {
       config.alexa.ssl = false;
     }
@@ -167,18 +155,11 @@ async function runAutoconfig(interactive, config) {
           dirty = true;
         }
       });
-<<<<<<< HEAD
     } else {
       if (config.alexa.ssh !== config.alexa.ssh.trim()) {
         config.alexa.ssh = config.alexa.ssh.trim();
         dirty = true;
       }
-=======
-    }
-    if (!config.alexa.hasOwnProperty('disableCustomSkill')) {
-      config.alexa.disableCustomSkill = true;
-      dirty = true
->>>>>>> 8f182e366362656eec43d6619b5993aeaeba0e16
     }
 
     // Search for FHEM, if no connections..
@@ -503,7 +484,6 @@ async function runAutoconfig(interactive, config) {
       return {"bearerToken": bearerToken};
     }
   }
-<<<<<<< HEAD
   if (interactive) {
     while (true) {
       const a = readline.question("We are done - start the server from commandline? [y/n] ");
@@ -513,8 +493,6 @@ async function runAutoconfig(interactive, config) {
         return "User request";
     }
   }
-=======
->>>>>>> 8f182e366362656eec43d6619b5993aeaeba0e16
 }
 
 

--- a/lib/user.js
+++ b/lib/user.js
@@ -486,10 +486,11 @@ async function runAutoconfig(interactive, config) {
   }
   if (interactive) {
     while (true) {
-      const a = readline.question("We are done - start the server from commandline? [y/n] ");
+      const a = readline.question("We are done - start the server from commandline?\n" +
+        "(Better way would be to continue via FHEM-WEB, unless you are debugging) [y/N] ");
       if (a === 'y')
         return undefined;
-      if (a === 'n')
+      if (a === 'n' || a === '')
         return "User request";
     }
   }

--- a/lib/user.js
+++ b/lib/user.js
@@ -101,7 +101,11 @@ async function runAutoconfig(interactive, config) {
 
   if (! config) {
     const configPath = User.configPath();
+<<<<<<< HEAD
+    config = {};
+=======
     let config = {};
+>>>>>>> 8f182e366362656eec43d6619b5993aeaeba0e16
     if (!fs.existsSync(configPath)) {
       if (fs.existsSync("./config-sample.json")) {
         console.log("config.json not existing, creating from ../config-sample.json");
@@ -132,7 +136,10 @@ async function runAutoconfig(interactive, config) {
     // Default settings for alexa-fhem
     if (!config.alexa.hasOwnProperty('port')) {
       config.alexa.port = 3000;
+<<<<<<< HEAD
+=======
       dirty = true
+>>>>>>> 8f182e366362656eec43d6619b5993aeaeba0e16
     }
     if (!config.alexa.hasOwnProperty('name')) {
       config.alexa.name = 'Alexa';
@@ -142,6 +149,10 @@ async function runAutoconfig(interactive, config) {
       config.alexa['bind-ip'] = '127.0.0.1';
       dirty = true
     }
+<<<<<<< HEAD
+
+=======
+>>>>>>> 8f182e366362656eec43d6619b5993aeaeba0e16
     if (!config.alexa.hasOwnProperty('ssl')) {
       config.alexa.ssl = false;
     }
@@ -156,10 +167,18 @@ async function runAutoconfig(interactive, config) {
           dirty = true;
         }
       });
+<<<<<<< HEAD
+    } else {
+      if (config.alexa.ssh !== config.alexa.ssh.trim()) {
+        config.alexa.ssh = config.alexa.ssh.trim();
+        dirty = true;
+      }
+=======
     }
     if (!config.alexa.hasOwnProperty('disableCustomSkill')) {
       config.alexa.disableCustomSkill = true;
       dirty = true
+>>>>>>> 8f182e366362656eec43d6619b5993aeaeba0e16
     }
 
     // Search for FHEM, if no connections..
@@ -484,6 +503,18 @@ async function runAutoconfig(interactive, config) {
       return {"bearerToken": bearerToken};
     }
   }
+<<<<<<< HEAD
+  if (interactive) {
+    while (true) {
+      const a = readline.question("We are done - start the server from commandline? [y/n] ");
+      if (a === 'y')
+        return undefined;
+      if (a === 'n')
+        return "User request";
+    }
+  }
+=======
+>>>>>>> 8f182e366362656eec43d6619b5993aeaeba0e16
 }
 
 


### PR DESCRIPTION
a) -A ist drin. Fragt jetzt am Ende, ob auch den Server hochziehen oder nicht.
b) Bugfix setreading wie besprochen

Ich gucke mir jetzt noch den Thermostat-Mode an. Beispiel für "-A" (ist mit der normalen alexa-fhem.cfg glücklich):

fhem@raspberrypi:~/alexa-fhem$ bin/alexa -c /opt/fhem/alexa-fhem.cfg -A
FHEM-Connectivity fine, CSRF-Token: csrf_280332168871155
existing config.json seems fine
SSH key seems to exist
Our SSH key is known at the reverse proxy, good!
[2019-1-8 20:39:58]   executing: http://localhost:8083/fhem?cmd=jsonlist2%20TYPE%3Dalexa&fwcsrf=csrf_280332168871155&XHR=1
[2019-1-8 20:39:59] 39_alexa.pm is new version: 324
We are done - start the server from commandline? [y/n] n
[2019-1-8 20:40:01] User request
Startup rejected. Reason: User request
