### PR TITLE
Added Support for Alexa ModeController  and multiple ModeControllers

### DIFF
--- a/lib/fhem.js
+++ b/lib/fhem.js
@@ -1032,7 +1032,12 @@ FHEMDevice.prototype.unsubscribe = function(mapping, characteristic) {
     if( mapping === undefined ) {
       for( let characteristic_type in this.mappings ) {
         var mapping = this.mappings[characteristic_type];
-        FHEM_unsubscribe(this, mapping.informId, characteristic);
+        if( characteristic_type === "ModeController"){
+          for( var key in mapping.instance)
+            FHEM_unsubscribe(this,  mapping.instance[key].informId, characteristic);
+        }else{
+          FHEM_unsubscribe(this, mapping.informId, characteristic);
+        }
       }
 
     } else if( typeof mapping === 'object' ) {
@@ -1061,6 +1066,17 @@ FHEMDevice.prototype.fromHomebridgeMapping = function(homebridgeMapping) {
       } catch(err) {
         this.log.error( '  fromHomebridgeMapping JSON.parse: ' + err );
         return;
+      }
+
+      if( Array.isArray(homebridgeMapping.ModeController)){
+        var mcs = {};
+        homebridgeMapping.ModeController.forEach(function (ModeController){
+          var name = ModeController.asset.split(":")[0];
+          var obj = { [name] : ModeController};
+          Object.assign(mcs, obj);
+        })
+        var obj = { "instance" : mcs };
+        homebridgeMapping.ModeController = obj;
       }
 
       //FIXME: handle multiple identical characteristics in this.mappings and in homebridgeMapping ?
@@ -1188,6 +1204,17 @@ FHEMDevice.prototype.fromHomebridgeMapping = function(homebridgeMapping) {
 
         }
       }
+    }
+
+    if( Array.isArray(homebridgeMapping.ModeController)){
+      var mcs = {};
+      homebridgeMapping.ModeController.forEach(function (ModeController){
+        var name = ModeController.asset.split(":")[0];
+        var obj = { [name] : ModeController};
+        Object.assign(mcs, obj);
+      })
+      var obj = { "instance" : mcs };
+      homebridgeMapping.ModeController = obj;
     }
 }
 
@@ -1353,9 +1380,13 @@ FHEM.prototype.updateAlexaDevice = function() {
                       this.xxx.fromHomebridgeMapping( this.alexa_device.Attributes.alexaMapping );
                       for( let characteristic_type in this.xxx.mappings ) {
                         var mappings = this.xxx.mappings[characteristic_type];
+
+                        if( characteristic_type === "ModeController")
+                           mappings = Object.values(mappings.instance)
+
                         if( !Array.isArray(mappings) )
                            mappings = [mappings];
-
+                        
                         for( let mapping of mappings ) {
                           var device = this.device;
                           if( mapping.device === undefined )
@@ -2649,6 +2680,10 @@ FHEMDevice(platform, s) {
     this.log.info( s.Internals.NAME + ' has' );
     for( let characteristic_type in this.mappings ) {
       var mappings = this.mappings[characteristic_type];
+
+      if( characteristic_type === "ModeController")
+         mappings = Object.values(mappings.instance)
+
       if( !Array.isArray(mappings) )
          mappings = [mappings];
 
@@ -2740,6 +2775,10 @@ FHEMDevice(platform, s) {
   // prepare mapping internals
   for( let characteristic_type in this.mappings ) {
     var mappings = this.mappings[characteristic_type];
+
+    if( characteristic_type === "ModeController")
+      mappings = Object.values(mappings.instance)
+
     if( !Array.isArray(mappings) )
        mappings = [mappings];
 

--- a/lib/fhem.js
+++ b/lib/fhem.js
@@ -1206,15 +1206,15 @@ FHEMDevice.prototype.fromHomebridgeMapping = function(homebridgeMapping) {
       }
     }
 
-    if( Array.isArray(homebridgeMapping.ModeController)){
+    if( Array.isArray(this.mappings.ModeController)){
       var mcs = {};
-      homebridgeMapping.ModeController.forEach(function (ModeController){
+      this.mappings.ModeController.forEach(function (ModeController){
         var name = ModeController.asset.split(":")[0];
         var obj = { [name] : ModeController};
         Object.assign(mcs, obj);
       })
       var obj = { "instance" : mcs };
-      homebridgeMapping.ModeController = obj;
+      this.mappings.ModeController = obj;
     }
 }
 

--- a/lib/fhem.js
+++ b/lib/fhem.js
@@ -1068,8 +1068,11 @@ FHEMDevice.prototype.fromHomebridgeMapping = function(homebridgeMapping) {
         return;
       }
 
-      if( Array.isArray(homebridgeMapping.ModeController)){
+      if( 'ModeController' in homebridgeMapping){
         var mcs = {};
+        if(!Array.isArray(homebridgeMapping.ModeController)){
+          homebridgeMapping.ModeController = [homebridgeMapping.ModeController];
+        }
         homebridgeMapping.ModeController.forEach(function (ModeController){
           var name = ModeController.asset.split(":")[0];
           var obj = { [name] : ModeController};
@@ -1206,7 +1209,11 @@ FHEMDevice.prototype.fromHomebridgeMapping = function(homebridgeMapping) {
       }
     }
 
-    if( Array.isArray(this.mappings.ModeController)){
+    if( 'ModeController' in  this.mappings){
+      var mcs = {};
+      if(!Array.isArray( this.mappings.ModeController)){
+        this.mappings.ModeController = [ this.mappings.ModeController];
+      }
       var mcs = {};
       this.mappings.ModeController.forEach(function (ModeController){
         var name = ModeController.asset.split(":")[0];

--- a/lib/fhem.js
+++ b/lib/fhem.js
@@ -1211,10 +1211,9 @@ FHEMDevice.prototype.fromHomebridgeMapping = function(homebridgeMapping) {
 
     if( 'ModeController' in  this.mappings){
       var mcs = {};
-      if(!Array.isArray( this.mappings.ModeController)){
-        this.mappings.ModeController = [ this.mappings.ModeController];
+      if(!Array.isArray(this.mappings.ModeController)){
+        this.mappings.ModeController = [this.mappings.ModeController];
       }
-      var mcs = {};
       this.mappings.ModeController.forEach(function (ModeController){
         var name = ModeController.asset.split(":")[0];
         var obj = { [name] : ModeController};

--- a/lib/server.js
+++ b/lib/server.js
@@ -576,13 +576,9 @@ Server.prototype.addDevice = function(device, fhem) {
 
   for( let characteristic_type in device.mappings ){
     if (characteristic_type === 'ModeController'){
-      if(device.alexaRoom === 'debug'){
         (Object.values(device.mappings[characteristic_type].instance)).forEach(function (mode){
           device.subscribe( mode );
         })
-      }else{
-        device.subscribe( device.mappings[characteristic_type] );
-      }
     }else{
       device.subscribe( device.mappings[characteristic_type] );
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -574,8 +574,19 @@ Server.prototype.addDevice = function(device, fhem) {
 
   this.devices[device.device.toLowerCase()] = device;
 
-  for( let characteristic_type in device.mappings )
-    device.subscribe( device.mappings[characteristic_type] );
+  for( let characteristic_type in device.mappings ){
+    if (characteristic_type === 'ModeController'){
+      if(device.alexaRoom === 'debug'){
+        (Object.values(device.mappings[characteristic_type].instance)).forEach(function (mode){
+          device.subscribe( mode );
+        })
+      }else{
+        device.subscribe( device.mappings[characteristic_type] );
+      }
+    }else{
+      device.subscribe( device.mappings[characteristic_type] );
+    }
+  }
 
   if( device.alexaRoom ) {
     device.alexaRoom = device.alexaRoom.toLowerCase().replace( /\+/g, ' ' );
@@ -2373,7 +2384,8 @@ var handler = function(event, callback) {
         break;
 
       case NAMESPACE_ModeController:
-        response = handleModeController.bind(this)(event);
+        //response = handleModeController.bind(this)(event);
+        response = handleMode.bind(this)(event);
         break;
 
       default:
@@ -3387,69 +3399,82 @@ function deviceToEndpoints(device) {
                        );
   }
 
-  if( device.isOfType('mode') && mappings.ModeController ) {
-    var mapping = mappings.ModeController;
-    d.capabilities.push( {
-                           "type": "AlexaInterface",
-                           "interface": NAMESPACE_ModeController,
-	                   "instance": instanceForMode(device, mapping),
-                           "version": "3",
-                           "properties": {
-                             "supported": [
-                               { "name": "mode" },
-                             ],
-                             "proactivelyReported": device.proactiveEvents,
-                             "retrievable": true,
-		             "nonControllable": false
-                           },
-	                   "capabilityResources": {
-                             "friendlyNames": [
-                               {
-                                 "@type": "text",
-                                 "value": {
-                                   "text": mapping.mode || "mode",
-                                   "locale": mapping.locale || "de-DE"
-                                 }
-                               }
-                             ]
-                           },
-                           "configuration": {
-		             "ordered": (mapping.ordered?true:false) || false,
-                             "supportedModes": [
-                             ]
-                           },
-                           "semantics": {
-                           }
-                         }
-                       );
+  if( mappings.ModeController ) {
+    for (var keys of Object.keys(mappings.ModeController.instance)) {
+      log.debug(keys + " -> " + mappings.ModeController.instance[keys])
+      var instance = mappings.ModeController.instance[keys];
+      var assets = []; 
+      var asset = instance.asset.split(':')
+      var a_name = asset[0];
+      assets.push({
+        "@type": "asset",
+        "value": {
+          "assetId": "Alexa.Setting." + a_name,
+        }
+      })
+      asset.forEach(function(fname,i){
+        if(i > 0){
+          log.debug("Index:" + i);
+          var a_utterance = fname;
+          assets.push({
+                        "@type": "text",
+                        "value": {
+                          "text": a_utterance,
+                          "locale" : instance.locale, 
+                        }
+                      })
+        }
+      })
 
-	
-    if( typeof mapping.value2homekit === 'object' ) {
-      let modes = [];
-      for( let from of Object.keys(mapping.value2homekit) ) {
-        let to = mapping.value2homekit[from];
-        modes.push( {
-		      "value": valueForMode(device, mapping, from),
-		      "modeResources": {
-		        "friendlyNames": [
-		          {
-                            "@type": "text",
-                            "value": {
-                              "text": to,
-                              "locale": mapping.locale || "de-DE"
-                            }
-                          }
-		        ]
+      var modes = [];
+      instance.values.forEach(function(mode){
+        var mode = mode.split(':');
+        var m_name = mode[0];
+        var fnames = [];
+        mode.forEach(function(fname, i){
+          if(i > 0){      
+            var m_utterance = fname;
+            fnames.push({
+                        "@type": "text",
+                        "value": {
+                            "text": m_utterance,
+                            "locale": instance.locale,
+                        }
+                      })
+          }
+        });
+        modes.push ({
+                      "value": a_name + "." + m_name,
+                      "modeResources": {
+                          "friendlyNames": fnames
                       }
-                    } );
-      }
-      let configuration = d.capabilities[d.capabilities.length-1].configuration;
-      configuration.supportedModes = modes;
-      //log.error(d.capabilities);
-    }
+                  });
 
-    if( !d.displayCategories.length )
-      d.displayCategories.push ( 'OTHER' );
+      });
+      d.capabilities.push({
+                              "type": "AlexaInterface",
+                              "interface": NAMESPACE_ModeController,
+                              "instance": device.device + "." + a_name,
+                              "version": "3",
+                              "properties": {
+                                "supported": [
+                                  {
+                                    "name" : "mode"
+                                  }
+                                ],
+                              "retrievable": true,
+                              "proactivelyReported": device.proactiveEvents,
+                              "nonControllable": false
+                              }, 
+                              "capabilityResources": {
+                                "friendlyNames": assets
+                              },
+                              "configuration" : {
+                                "ordered": false,
+                                "supportedModes": modes
+                              }
+                          });
+      }
   }
 
   if( mappings.Hue || mappings.RGB ) {
@@ -4143,6 +4168,27 @@ var handleModeController = function(event) {
   return { "context": context, "event": { "header": header, "endpoint": endpoint , "payload": {} } };
 
 }// handleModeController
+
+var handleMode = function(event) {
+  var device = this.devices[event.directive.endpoint.cookie.device.toLowerCase()];
+  if( !device )
+    return createError(ERROR3_NO_SUCH_ENDPOINT, undefined, event);
+  var instance = event.directive.header.instance.split('.')[1];
+  var mode = event.directive.payload.mode.split('.')[1];
+  var mapping = Object.assign({}, device.mappings.ModeController, device.mappings.ModeController.instance[instance]);
+  delete mapping.instance;
+  device.command( mapping, mode );
+
+  var header = createHeader("Alexa", "Response", event);
+  var context = {
+    "properties": []
+  };
+  var endpoint = { "scope": event.directive.endpoint.scope, "endpointId": event.directive.endpoint.endpointId};
+
+  return { "context": context, "event": { "header": header, "endpoint": endpoint , "payload": {} } };
+}// handleModeController
+
+
 
 var handleThermostatController = function(event) {
   var device = this.devices[event.directive.endpoint.cookie.device.toLowerCase()];

--- a/lib/server.js
+++ b/lib/server.js
@@ -4477,26 +4477,7 @@ var handlePlayback = function(event) {
 
   var header = createHeader("Alexa", "Response", event);
   var context = {
-    "properties": [
-        {
-          "namespace": "Alexa.PlaybackStateReporter",
-          "name": "playbackState",
-          "value": {
-              "state": "STOPPED"
-          },
-          "timeOfSample": "2021-12-01T18:20:50Z",
-          "uncertaintyInMilliseconds": 0
-        },
-        {
-          "namespace": "Alexa.EndpointHealth",
-          "name": "connectivity",
-          "value": {
-              "value": "OK"
-          },
-          "timeOfSample": "2021-12-01T18:20:50Z",
-          "uncertaintyInMilliseconds": 0
-        }
-    ]
+    "properties": []
   };
   var endpoint = { "scope": event.directive.endpoint.scope, "endpointId": event.directive.endpoint.endpointId};
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -4477,7 +4477,26 @@ var handlePlayback = function(event) {
 
   var header = createHeader("Alexa", "Response", event);
   var context = {
-    "properties": []
+    "properties": [
+        {
+          "namespace": "Alexa.PlaybackStateReporter",
+          "name": "playbackState",
+          "value": {
+              "state": "STOPPED"
+          },
+          "timeOfSample": "2021-12-01T18:20:50Z",
+          "uncertaintyInMilliseconds": 0
+        },
+        {
+          "namespace": "Alexa.EndpointHealth",
+          "name": "connectivity",
+          "value": {
+              "value": "OK"
+          },
+          "timeOfSample": "2021-12-01T18:20:50Z",
+          "uncertaintyInMilliseconds": 0
+        }
+    ]
   };
   var endpoint = { "scope": event.directive.endpoint.scope, "endpointId": event.directive.endpoint.endpointId};
 


### PR DESCRIPTION
Hello,

i have added Alexa Mode Controller support. Also Multiple Mode-Controllers are possible.
Homebridge Mapping:

ModeController:asset=Mode:Steuerung,values=Left:Links;Ok:Ok:Auswählen;Right:Rechts;Up:Rauf;Down:Runter;Wakeup:Aufwecken,reading=diplaymode,cmd=displaymode,locale=de-de
ModeController:asset=Preset:Auswahl,values=Small:Klein;Large:Groß,reading=presetmode,cmd=presetmode,locale=de-de

| asset = |  Mode : |  Steuerung|
|---------|---------|------------|
|Modecontroller asset| Alexa.Setting.Mode| Friendly Name|

| values = | Left : | Links| , Ok : |  Ok : |  Auswählen|
|----------|------|------|---------|---------|------------|
Modecontroller mode |Alexa.Mode.Left |Friendly Name  |Alexa.Mode.Ok | Friendly Name | Friendly Name|

|reading=presetmode |,cmd=presetmode | ,locale=de-de |
|----------------------|-------------------|---------------|
|         reading             |       command      |      locale for firendly names |

If you need more information we can also discuss in German ;-)