### PR TITLE
on IntentRequests the confirmationStatus will be evaluated

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1634,78 +1634,81 @@ log.info( intent_name );
 
           var name = fhem.fhemIntents[intent_name];
 
-          var applicationId = '';
-          if( this._config.alexa.applicationId.length > 1 && event.session.application && event.session.application.applicationId ) {
-            applicationId = event.session.application.applicationId;
-            //applicationId = this._config.alexa.applicationId.indexOf(event.session.application.applicationId);
-            //if( applicationId < 0 ) applicationId = '';
-          }
-
-          if( name.match(/^(set|get|attr)\s/) ) {
-            if( applicationId !== '' ) applicationId = ' :' +applicationId;
-            //fhem.execute( 'setreading '+ fhem.alexa_device.Name +' fhemIntent '+ intent_name + applicationId );
-            fhem.execute( 'setreading '+ fhem.alexa_device.Name +' fhemIntent '+ intent_name + applicationId + ';setreading '+ fhem.alexa_device.Name +' person '+ person + ';setreading '+ fhem.alexa_device.Name +' echoId '+ echoId + ';setreading '+ fhem.alexa_device.Name +' echoRoom '+ echoRoom +';'+ name, function(result) {
-              response.response.outputSpeech.text = result;
-              callback( response );
-            } );
-            return;
-
-          } else if( name.match(/^{.*}$/) ) {
-            if( applicationId !== '' ) applicationId = ' :' +applicationId;
-            //fhem.execute( 'setreading '+ fhem.alexa_device.Name +' fhemIntent '+ intent_name + applicationId );
-
-            var specials ='';
-            if( echoRoom !== 'unknown' )
-              specials += '"%Room" => "'+ echoRoom +'",';
-            if( skillRoom !== 'unknown' )
-              specials += '"%Room" => "'+ skillRoom +'",';
-
-            if( event.request.intent.slots ) {
-              for( let slot in event.request.intent.slots ) {
-                slot = event.request.intent.slots[slot];
-                var n = slot.name.replace( intent_name+'_', '' );
-                var v = slot.value;
-//console.log(n +': '+ v);
-                if( v !== undefined )
-                  specials += '"%'+ n +'" => "'+ v +'",';
-                else
-                  specials += '"%'+ n +'" => "",';
-              }
-
-              specials += '"%_person" => "'+ person +'",';
-              specials += '"%_echoId" => "'+ echoId +'",';
-              if( event.session.application !== undefined && event.session.application.applicationId !== undefined )
-                specials += '"%_applicationId" => "'+ event.session.application.applicationId +'",';
-              if( echoRoom !== 'unknown' )
-                specials += '"%_echoRoom" => "'+ echoRoom +'",';
-              if( skillRoom !== 'unknown' )
-                specials += '"%_skillRoom" => "'+ skillRoom +'",';
+log.info( event.request.intent.confirmationStatus );
+          if (event.request.intent.confirmationStatus !== "DENIED") {
+            var applicationId = '';
+            if( this._config.alexa.applicationId.length > 1 && event.session.application && event.session.application.applicationId ) {
+              applicationId = event.session.application.applicationId;
+              //applicationId = this._config.alexa.applicationId.indexOf(event.session.application.applicationId);
+              //if( applicationId < 0 ) applicationId = '';
             }
-console.log(specials);
 
-            name = '{my %specials=('+specials+');; my $exec = EvalSpecials(\''+name+'\', %specials);; return AnalyzePerlCommand($defs{"'+fhem.alexa_device.Name+'"}, $exec)}';
-//console.log(name);
+            if( name.match(/^(set|get|attr)\s/) ) {
+              if( applicationId !== '' ) applicationId = ' :' +applicationId;
+              //fhem.execute( 'setreading '+ fhem.alexa_device.Name +' fhemIntent '+ intent_name + applicationId );
+              fhem.execute( 'setreading '+ fhem.alexa_device.Name +' fhemIntent '+ intent_name + applicationId + ';setreading '+ fhem.alexa_device.Name +' person '+ person + ';setreading '+ fhem.alexa_device.Name +' echoId '+ echoId + ';setreading '+ fhem.alexa_device.Name +' echoRoom '+ echoRoom +';'+ name, function(result) {
+                response.response.outputSpeech.text = result;
+                callback( response );
+              } );
+              return;
 
-            fhem.execute( 'setreading '+ fhem.alexa_device.Name +' fhemIntent '+ intent_name + applicationId + ';setreading '+ fhem.alexa_device.Name +' person '+ person +';setreading '+ fhem.alexa_device.Name +' echoId '+ echoId + ';setreading '+ fhem.alexa_device.Name +' echoRoom '+ echoRoom +';'+ name, function(result) {
-              if( match = result.match( /^&(.*)/ ) ) {
-                result = match[1];
-                response.response.shouldEndSession = false;
+            } else if( name.match(/^{.*}$/) ) {
+              if( applicationId !== '' ) applicationId = ' :' +applicationId;
+              //fhem.execute( 'setreading '+ fhem.alexa_device.Name +' fhemIntent '+ intent_name + applicationId );
+
+              var specials ='';
+              if( echoRoom !== 'unknown' )
+                specials += '"%Room" => "'+ echoRoom +'",';
+              if( skillRoom !== 'unknown' )
+                specials += '"%Room" => "'+ skillRoom +'",';
+
+              if( event.request.intent.slots ) {
+                for( let slot in event.request.intent.slots ) {
+                  slot = event.request.intent.slots[slot];
+                  var n = slot.name.replace( intent_name+'_', '' );
+                  var v = slot.value;
+  //console.log(n +': '+ v);
+                  if( v !== undefined )
+                    specials += '"%'+ n +'" => "'+ v +'",';
+                  else
+                    specials += '"%'+ n +'" => "",';
+                }
+
+                specials += '"%_person" => "'+ person +'",';
+                specials += '"%_echoId" => "'+ echoId +'",';
+                if( event.session.application !== undefined && event.session.application.applicationId !== undefined )
+                  specials += '"%_applicationId" => "'+ event.session.application.applicationId +'",';
+                if( echoRoom !== 'unknown' )
+                  specials += '"%_echoRoom" => "'+ echoRoom +'",';
+                if( skillRoom !== 'unknown' )
+                  specials += '"%_skillRoom" => "'+ skillRoom +'",';
               }
-              response.response.outputSpeech.text = result;
+  console.log(specials);
 
-              if( match = result.match( /^<speak>(.*)<\/speak>$/ ) ) {
-                delete response.response.outputSpeech.text;
-                response.response.outputSpeech.type = "SSML";
-                response.response.outputSpeech.ssml = result;
-              }
+              name = '{my %specials=('+specials+');; my $exec = EvalSpecials(\''+name+'\', %specials);; return AnalyzePerlCommand($defs{"'+fhem.alexa_device.Name+'"}, $exec)}';
+  //console.log(name);
 
-              callback( response );
-            } );
-            return;
+              fhem.execute( 'setreading '+ fhem.alexa_device.Name +' fhemIntent '+ intent_name + applicationId + ';setreading '+ fhem.alexa_device.Name +' person '+ person +';setreading '+ fhem.alexa_device.Name +' echoId '+ echoId + ';setreading '+ fhem.alexa_device.Name +' echoRoom '+ echoRoom +';'+ name, function(result) {
+                if( match = result.match( /^&(.*)/ ) ) {
+                  result = match[1];
+                  response.response.shouldEndSession = false;
+                }
+                response.response.outputSpeech.text = result;
 
-          } else {
-            if( applicationId !== '' ) applicationId = ' :' +applicationId;
-            fhem.execute( 'setreading '+ fhem.alexa_device.Name +' person '+ person + ';setreading '+ fhem.alexa_device.Name +' echoId '+ echoId + ';setreading '+ fhem.alexa_device.Name +' echoRoom '+ echoRoom + ';' + 'setreading '+ fhem.alexa_device.Name +' fhemIntent '+ name + applicationId );
+                if( match = result.match( /^<speak>(.*)<\/speak>$/ ) ) {
+                  delete response.response.outputSpeech.text;
+                  response.response.outputSpeech.type = "SSML";
+                  response.response.outputSpeech.ssml = result;
+                }
+
+                callback( response );
+              } );
+              return;
+
+            } else {
+              if( applicationId !== '' ) applicationId = ' :' +applicationId;
+              fhem.execute( 'setreading '+ fhem.alexa_device.Name +' person '+ person + ';setreading '+ fhem.alexa_device.Name +' echoId '+ echoId + ';setreading '+ fhem.alexa_device.Name +' echoRoom '+ echoRoom + ';' + 'setreading '+ fhem.alexa_device.Name +' fhemIntent '+ name + applicationId );
+            }
           }
         }
       }


### PR DESCRIPTION
If in an indent a confirmation is required (that is, when Alexa should ask the user for a confirmation of the command), the "confirmationStatus" inicates the result of this confirmation. The value is either "CONFIRMED" or "DENIED" (refer to https://developer.amazon.com/en-US/docs/alexa/custom-skills/dialog-interface-reference.html#details)

My pull request implements this confirmationStatus. Only if the value is not "DENIED", the command will be submitted to FHEM.
I use "not DENIED" rather than "CONFIRMED" in case the confirmationStatus is undefined
